### PR TITLE
Changed the adjascent attribute to MutableSet

### DIFF
--- a/app/src/main/java/com/google/ar/core/examples/java/database/Node.kt
+++ b/app/src/main/java/com/google/ar/core/examples/java/database/Node.kt
@@ -13,8 +13,8 @@ data class Node(
         @ColumnInfo(name = "x") val x: Float,
         @ColumnInfo(name = "y") val y: Float,
         @ColumnInfo(name = "z") val z: Float,
-        @ColumnInfo(name = "name") val name: String?,
-        @ColumnInfo(name = "adj") val adj: List<Node>?
+        @ColumnInfo(name = "name") val name: String?, //A null value in this field means it's a "walkable" node.
+        @ColumnInfo(name = "adj") val adj: MutableSet<Node>?
 )
 
 class Converters {


### PR DESCRIPTION
Changed the adj (adjascent) attribute for Node from List to MutableSet. It needs to be a Mutable collection as it will be updated in runtime, and we should also set it as Set so we don't have to worry about duplicate values (or order).
 